### PR TITLE
fixed getIncome for user

### DIFF
--- a/backend/controllers/incomeController.js
+++ b/backend/controllers/incomeController.js
@@ -32,14 +32,18 @@ exports.addIncome = async (req, res) => {
 
 exports.getIncome = async (req, res) => {
   try {
-    const userId = req.user._id;
-    const userIncome = await IncomeSchema.find({ userId }).sort({
+    const user = req.user._id.toString();
+    console.log(user);
+    const userIncome = await IncomeSchema.find({
+      userId: user,
+    }).sort({
       createdAt: -1,
     });
+    console.log(userIncome);
     res.status(200).json(userIncome);
   } catch (error) {
     res.status(500).json({
-      message: "Error retrieving all incomes in DB. Check Server.",
+      message: "Error retrieving incomes for user. Check Server.",
       error: error.message,
     });
   }

--- a/backend/middleware/authentication.js
+++ b/backend/middleware/authentication.js
@@ -14,6 +14,7 @@ const auth = async (req, res, next) => {
     }
     req.token = token;
     req.user = user;
+    // console.log(req.user);
     next();
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
**Description**

- Fixed back end route to get Income for a specific user. 

- The fix included updating how I used the `find()` abstract function for searching userID in the IncomeSchema. The bug returns the correct array of objects: 

Based on its current state, here is the flow on how it was tested.

Postman: 
/get-income 
Add a Bearer token as authorization 
call the GET method 
response should be: 

`
[
    {
        "_id": "64304e1a4cf315967407b8e8",
        "userId": "641df6efd9d9d6584b2c3b64",
        "title": "Salary Bonus",
        "amount": 200000,
        "type": "income",
        "date": "2023-03-28T00:00:00.000Z",
        "category": "income",
        "description": "bonus money",
        "createdAt": "2023-04-07T17:08:42.540Z",
        "updatedAt": "2023-04-07T17:08:42.540Z",
        "__v": 0
    }
]
`
  